### PR TITLE
Declare free variables for byte-compile warnings

### DIFF
--- a/find-and-ctags.el
+++ b/find-and-ctags.el
@@ -70,10 +70,10 @@
   "The options to update TAGS. The path of TAGS is key. Command line options is value.")
 
 ;; Is Microsoft Windows?
-(setq fctags-windows-p (eq system-type 'windows-nt))
+(defconst fctags-windows-p (eq system-type 'windows-nt))
 
 ;; Timer to run auto-update TAGS.
-(setq fctags-updated-timer nil)
+(defvar fctags-updated-timer nil)
 
 (defun fctags--guess-gnu-find ()
   (let ((rlt "find"))


### PR DESCRIPTION
There are some warnings about free variables.

```
find-and-ctags.el:73:7:Warning: assignment to free variable `fctags-windows-p'
find-and-ctags.el:76:7:Warning: assignment to free variable
    `fctags-updated-timer'

In fctags--guess-gnu-find:
find-and-ctags.el:80:9:Warning: reference to free variable `fctags-windows-p'

In fctags-auto-update-tags:
find-and-ctags.el:187:10:Warning: reference to free variable
    `fctags-updated-timer'
find-and-ctags.el:190:51:Warning: assignment to free variable
    `fctags-updated-timer'
```
